### PR TITLE
fix amount=0 failing existence check

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -84,7 +84,7 @@ async function getTransactionResponse(
     body: req.body,
   });
 
-  if (!amount || !action || !saleorApiUrl) {
+  if (typeof amount !== "undefined" || !action || !saleorApiUrl) {
     logger.error("Missing parameter");
     return Response.BadRequest({
       message: "Missing params",
@@ -131,7 +131,7 @@ async function getActionResponse(
     });
   }
 
-  if (!amount || !saleorApiUrl) {
+  if (typeof amount !== "undefined" || !saleorApiUrl) {
     logger.error("Missing amount or saleorApiUrl");
     return Response.BadRequest({
       pspReference: `${action}-1234`,


### PR DESCRIPTION
If shipping is set to Click and Collect, the charge amount becomes 0 ( I think, at least I'm receiving 0 ) and since !!(0) == false, it would fail. Better to check typeof